### PR TITLE
Client errors and notify signature change

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ const changedDocument = await client.getOne('tests', { query: { id: document.id 
 // client.on('DELETE:/tests/.*', ...)
 // client.on('(PUT|PATCH):/tests/uuid-uuid-uuid-uuid', ...)
 
-client.on('POST:/tests/.*', (path, resource, pattern) => {
+client.on('POST:/tests/.*', (path, collectionId, resourceId, pattern) => {
   console.log(path) // === 'POST:/tests/uuid-uuid-uuid-uuid'
-  console.log(resource) // === '/tests/uuid-uuid-uuid-uuid'
+  console.log(collectionId) // === 'tests'
+  console.log(resourceId) // === 'uuid-uuid-uuid-uuid'
   console.log(pattern) // === 'POST:/tests/.*'
 })
 

--- a/client/index.js
+++ b/client/index.js
@@ -53,8 +53,8 @@ function client (rootUrl, clientOptions) {
     const url = `${rootUrl}/${collectionId}?${query}`;
     https.request(url, { agent: httpsAgent }, async function (response) {
       const data = await finalStream(response).then(JSON.parse);
-      if (response.statusCode >= 500) {
-        callback(Object.assign(new Error('canhazdb error'), { data }));
+      if (response.statusCode >= 400) {
+        callback(Object.assign(new Error('canhazdb error'), { data, statusCode: response.statusCode }));
         return;
       }
 
@@ -89,8 +89,8 @@ function client (rootUrl, clientOptions) {
     https.request(url, { agent: httpsAgent }, async function (response) {
       const data = await finalStream(response).then(JSON.parse);
 
-      if (response.statusCode >= 500) {
-        callback(Object.assign(new Error('canhazdb error'), { data }));
+      if (response.statusCode >= 400) {
+        callback(Object.assign(new Error('canhazdb error'), { data, statusCode: response.statusCode }));
         return;
       }
 
@@ -117,8 +117,8 @@ function client (rootUrl, clientOptions) {
     }, async function (response) {
       const data = await finalStream(response).then(JSON.parse);
 
-      if (response.statusCode >= 500) {
-        callback(Object.assign(new Error('canhazdb error'), { data }));
+      if (response.statusCode >= 400) {
+        callback(Object.assign(new Error('canhazdb error'), { data, statusCode: response.statusCode }));
         return;
       }
 
@@ -155,8 +155,8 @@ function client (rootUrl, clientOptions) {
     }, async function (response) {
       const data = await finalStream(response).then(JSON.parse);
 
-      if (response.statusCode >= 500) {
-        callback(Object.assign(new Error('canhazdb error'), { data }));
+      if (response.statusCode >= 400) {
+        callback(Object.assign(new Error('canhazdb error'), { data, statusCode: response.statusCode }));
         return;
       }
 
@@ -193,8 +193,8 @@ function client (rootUrl, clientOptions) {
     }, async function (response) {
       const data = await finalStream(response).then(JSON.parse);
 
-      if (response.statusCode >= 500) {
-        callback(Object.assign(new Error('canhazdb error'), { data }));
+      if (response.statusCode >= 400) {
+        callback(Object.assign(new Error('canhazdb error'), { data, statusCode: response.statusCode }));
         return;
       }
 
@@ -230,8 +230,8 @@ function client (rootUrl, clientOptions) {
     }, async function (response) {
       const data = await finalStream(response).then(JSON.parse);
 
-      if (response.statusCode >= 500) {
-        callback(Object.assign(new Error('canhazdb error'), { data }));
+      if (response.statusCode >= 400) {
+        callback(Object.assign(new Error('canhazdb error'), { data, statusCode: response.statusCode }));
         return;
       }
 
@@ -252,8 +252,8 @@ function client (rootUrl, clientOptions) {
     }, async function (response) {
       const data = await finalStream(response).then(JSON.parse);
 
-      if (response.statusCode >= 500) {
-        callback(Object.assign(new Error('canhazdb error'), { data }));
+      if (response.statusCode >= 400) {
+        callback(Object.assign(new Error('canhazdb error'), { data, statusCode: response.statusCode }));
         return;
       }
 
@@ -269,8 +269,8 @@ function client (rootUrl, clientOptions) {
     }, async function (response) {
       const data = await finalStream(response).then(JSON.parse);
 
-      if (response.statusCode >= 500) {
-        callback(Object.assign(new Error('canhazdb error'), { data }));
+      if (response.statusCode >= 400) {
+        callback(Object.assign(new Error('canhazdb error'), { data, statusCode: response.statusCode }));
         return;
       }
 
@@ -341,7 +341,7 @@ function client (rootUrl, clientOptions) {
       accepter && accepter[1] && accepter[1]();
       return;
     }
-    const handler = handlers.find(item => item[0] === data[2]);
+    const handler = handlers.find(item => item[0] === data[3]);
     handler[1](...data);
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canhazdb",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A shaded and clustered database communicated over http rest.",
   "main": "./index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "minimist": "^1.2.5",
     "mongo-sql": "^6.2.0",
     "mql-to-jql": "^1.1.8",
+    "ndjson-fe": "^1.2.6",
     "node-ejdb-lite": "^3.1.7",
     "qs": "^6.9.4",
     "reconnecting-websocket": "^4.4.0",

--- a/server/tcpHandler.js
+++ b/server/tcpHandler.js
@@ -97,13 +97,13 @@ async function get (state, request, response) {
   response.reply({ [STATUS]: 200, [DOCUMENTS]: documents });
 }
 
-function notify (notifyPath, resource, request) {
+function notify (notifyPath, collectionId, resourceId, request) {
   request.state.notifiers
     .filter(notifier => {
       return notifier[1].test(notifyPath);
     })
     .forEach(notifier => {
-      request.state.send([notifyPath, resource, notifier[0]]);
+      request.state.send([notifyPath, collectionId, resourceId, notifier[0]]);
     });
 }
 
@@ -119,7 +119,7 @@ async function post (state, request, response) {
 
   const document = await state.driver.post(collectionId, data[DOCUMENT]);
 
-  notify(`POST:/${collectionId}/${document.id}`, `/${collectionId}/${document.id}`, request);
+  notify(`POST:/${collectionId}/${document.id}`, collectionId, document.id, request);
 
   response.reply({
     [STATUS]: 201,
@@ -146,6 +146,8 @@ async function put (state, request, response) {
 
   const result = await state.driver.put(collectionId, data[DOCUMENT], query);
 
+  notify(`PUT:/${collectionId}/${resourceId}`, collectionId, resourceId, request);
+
   response.reply({ [STATUS]: 200, [DATA]: { changes: result.changes } });
 }
 
@@ -168,6 +170,8 @@ async function patch (state, request, response) {
 
   const result = await state.driver.patch(collectionId, data[DOCUMENT], query);
 
+  notify(`PATCH:/${collectionId}/${resourceId}`, collectionId, resourceId, request);
+
   response.reply({ [STATUS]: 200, [DATA]: { changes: result.changes } });
 }
 
@@ -189,6 +193,8 @@ async function del (state, request, response) {
   }
 
   const result = await state.driver.del(collectionId, query);
+
+  notify(`DELETE:/${collectionId}/${resourceId}`, collectionId, resourceId, request);
 
   response.reply({ [STATUS]: 200, [DATA]: { changes: result.changes } });
 }

--- a/server/wsHandler.js
+++ b/server/wsHandler.js
@@ -22,7 +22,7 @@ function wsHandler (server, state, options) {
   const listeners = {};
 
   state.handleMessage = function (message) {
-    const triggeredPath = message[2];
+    const triggeredPath = message[3];
     listeners[triggeredPath].forEach(socket => socket.send(JSON.stringify(['T', message])));
   };
 

--- a/test/client.js
+++ b/test/client.js
@@ -396,7 +396,7 @@ test('post and notify', async t => {
   let alreadyHandled = false;
 
   return new Promise((resolve) => {
-    async function handler (path, resource, pattern) {
+    async function handler (path, collectionId, resourceId, pattern) {
       if (alreadyHandled) {
         t.fail('handler should only be called once');
       }
@@ -410,12 +410,10 @@ test('post and notify', async t => {
       });
 
       t.equal(pattern, 'POST:/tests');
-
       t.ok(path.startsWith('POST:/tests/'), 'path starts with /tests/');
       t.equal(path.length, 48);
-
-      t.ok(resource.startsWith('/tests/'), 'path starts with /tests/');
-      t.equal(resource.length, 43);
+      t.equal(collectionId, 'tests');
+      t.equal(resourceId.length, 36);
 
       alreadyHandled = true;
     }

--- a/test/notify.js
+++ b/test/notify.js
@@ -14,7 +14,7 @@ const tls = {
 };
 
 test('notify: post some data', async t => {
-  t.plan(6);
+  t.plan(5);
 
   const cluster = await createTestCluster(3, tls);
   const node = cluster.getRandomNodeUrl();
@@ -39,17 +39,17 @@ test('notify: post some data', async t => {
       return;
     }
 
-    const [path, resource, pattern] = data;
-    t.equal(pattern, 'POST:/tests/.*');
-    t.ok(resource.startsWith('/tests/'));
-    t.equal(resource.length, 43);
+    const [path, collectionId, resourceId, pattern] = data;
+
     t.ok(path.startsWith('POST:/tests/'));
-    t.equal(path.length, 48);
+    t.equal(collectionId, 'tests');
+    t.equal(resourceId.length, 36);
+    t.equal(pattern, 'POST:/tests/.*');
   });
 });
 
 test('notify: twos posts', async t => {
-  t.plan(10);
+  t.plan(8);
 
   const cluster = await createTestCluster(3, tls);
   const node = cluster.getRandomNodeUrl();
@@ -79,24 +79,24 @@ test('notify: twos posts', async t => {
       return;
     }
 
-    store.sort((a, b) => a[2] > b[2] ? 1 : -1);
+    store.sort((a, b) => a[3] > b[3] ? 1 : -1);
 
     {
-      const [path, resource, pattern] = store[0];
-      t.equal(pattern, 'POST:/tests1/.*');
-      t.ok(resource.startsWith('/tests1/'));
-      t.equal(resource.length, 44);
+      const [path, collectionId, resourceId, pattern] = store[0];
+
       t.ok(path.startsWith('POST:/tests1/'));
-      t.equal(path.length, 49);
+      t.equal(collectionId, 'tests1');
+      t.equal(resourceId.length, 36);
+      t.equal(pattern, 'POST:/tests1/.*');
     }
 
     {
-      const [path, resource, pattern] = store[1];
-      t.equal(pattern, 'POST:/tests2/.*');
-      t.ok(resource.startsWith('/tests2/'));
-      t.equal(resource.length, 44);
+      const [path, collectionId, resourceId, pattern] = store[1];
+
       t.ok(path.startsWith('POST:/tests2/'));
-      t.equal(path.length, 49);
+      t.equal(collectionId, 'tests2');
+      t.equal(resourceId.length, 36);
+      t.equal(pattern, 'POST:/tests2/.*');
     }
   }
 
@@ -112,7 +112,7 @@ test('notify: twos posts', async t => {
 });
 
 test('notify: one not the other', async t => {
-  t.plan(6);
+  t.plan(5);
 
   const cluster = await createTestCluster(3, tls);
   const node = cluster.getRandomNodeUrl();
@@ -147,11 +147,11 @@ test('notify: one not the other', async t => {
       return;
     }
 
-    const [path, resource, pattern] = data;
-    t.equal(pattern, 'POST:/tests2/.*');
-    t.ok(resource.startsWith('/tests2/'));
-    t.equal(resource.length, 44);
+    const [path, collectionId, resourceId, pattern] = data;
+
     t.ok(path.startsWith('POST:/tests2/'));
-    t.equal(path.length, 49);
+    t.equal(collectionId, 'tests2');
+    t.equal(resourceId.length, 36);
+    t.equal(pattern, 'POST:/tests2/.*');
   });
 });


### PR DESCRIPTION
- The client will reject if a statusCode of 400 or more is returned from the server
- The notify signature has changed to `(path, collectionId, resourceId, pattern)`